### PR TITLE
Derived callback keys from keywords, not package qualified symbols

### DIFF
--- a/README.org
+++ b/README.org
@@ -106,27 +106,56 @@ bindings, e.g. ~--dynamic-space-size 2048~
 
 #+begin_src lisp :results silent :tangle examples/callback.lisp
   (defun callback ()
-      (iup:with-iup ()
-        (let* ((button
-                 (iup:button :title "&OK"
-                             :expand "YES"
-                             :tip "Exit button"
-                             :action (lambda (handle)
-                                       (iup:message "Message"
-                                                    (lisp-implementation-version))
-                                       iup:+close+)))
-               (label (iup:label :title (lisp-implementation-type)))
-               (vbox (iup:vbox (list label button)
-                               :gap "10"
-                               :margin "10x10"
-                               :alignment :acenter))
-               (dialog (iup:dialog vbox :title "Hello, World!")))
-          (iup:show dialog)
-          (iup:main-loop))))
+    (iup:with-iup ()
+      (let* ((button1
+               (iup:button :title "Test &1"
+                           :expand :yes
+                           :tip "Callback inline at control creation"
+                           :action (lambda (handle)
+                                     (message "button1's action callback")
+                                     iup:+default+)))
+             (button2
+               (iup:button :title "Test &2"
+                           :expand :yes
+                           :tip "Callback set later using (SETF (IUP:CALLBACK ..) ..)"))
+             (button3
+               (iup:button :title "Test &3"
+                           :expand :yes
+                           :tip "Callback example using symbol-referenced function at control creation"
+                           :action 'test3-callback))
+             (button4
+               (iup:button :title "Test &4"
+                           :expand :yes
+                           :tip "Callback example using symbol-referenced function later using (SETF (IUP:CALLBACK ..) ..)"))
+             (vbox
+               (iup:vbox (list button1 button2 button3 button4)
+                         :gap "10"
+                         :margin "10x10"
+                         :alignment :acenter))
+             (dialog
+               (iup:dialog vbox :title "Callback Example")))
+        (setf (iup:callback button2 :action)
+              (lambda (handle)
+                (message "button2's action callback")
+                iup:+default+))
+        (setf (iup:callback button4 :action) 'test4-callback)
+        (iup:show dialog)
+        (iup:main-loop))))
+
+  (defun test3-callback (handle)
+    (message "button3's action callback")
+    iup:+default+)
+
+  (defun test4-callback (handle)
+    (message "button4's action callback")
+    iup:+default+)
+
+  (defun message (message)
+    (iup:message "Callback Example" message))
 #+end_src
 
 #+begin_src lisp :results silent :tangle examples/callback.lisp
-  #-sbcl (hello)
+  #-sbcl (callback)
 
   ,#+sbcl
   (sb-int:with-float-traps-masked
@@ -1029,33 +1058,33 @@ are appended to a result panel.
   (defun drophash ()
     (iup:with-iup ()
       (let* ((list (iup:list :dropdown :yes
-			     :expand :horizontal
-			     :handlename "list"))
-	     (label (iup:flat-label :title "Drop files for hash"
-				    :alignment "ACENTER:ACENTER"
-				    :font "Helvetica, 24"
-				    :dropfilestarget :yes
-				    :dropfiles_cb 'drop-files-callback
-				    :expand :yes))
-	     (frame (iup:frame label))
-	     (results (iup:multi-line :expand :yes
-				      :readonly :yes
-				      :visiblelines 7
-				      :handlename "results"))
-	     (vbox (iup:vbox (list list
-				   frame
-				   (iup:sbox results :direction :north))
-			     :margin "10x10"
-			     :cgap 5))
-	     (dialog (iup:dialog vbox
-				 :title "Drop Hash"
-				 :size "HALFxHALF")))
-	(loop for digest in (ironclad:list-all-digests)
-	      for i from 1
-	      do (setf (iup:attribute list i) digest)
-	      finally (setf (iup:attribute list :valuestring) 'ironclad:sha256))
-	(iup:show dialog)
-	(iup:main-loop))))
+                             :expand :horizontal
+                             :handlename "list"))
+             (label (iup:flat-label :title "Drop files for hash"
+                                    :alignment "ACENTER:ACENTER"
+                                    :font "Helvetica, 24"
+                                    :dropfilestarget :yes
+                                    :dropfiles_cb 'drop-files-callback
+                                    :expand :yes))
+             (frame (iup:frame label))
+             (results (iup:multi-line :expand :yes
+                                      :readonly :yes
+                                      :visiblelines 7
+                                      :handlename "results"))
+             (vbox (iup:vbox (list list
+                                   frame
+                                   (iup:sbox results :direction :north))
+                             :margin "10x10"
+                             :cgap 5))
+             (dialog (iup:dialog vbox
+                                 :title "Drop Hash"
+                                 :size "HALFxHALF")))
+        (loop for digest in (ironclad:list-all-digests)
+              for i from 1
+              do (setf (iup:attribute list i) digest)
+              finally (setf (iup:attribute list :valuestring) 'ironclad:sha256))
+        (iup:show dialog)
+        (iup:main-loop))))
 #+end_src 
 
 When files are dropped onto the drop target (in this case, an IUP flat
@@ -1065,13 +1094,14 @@ file.
 
 #+begin_src lisp :results silent :tangle examples/drophash.lisp
   (defun drop-files-callback (handle filename num x y)
-    (let ((digest-hex 
-	    (ironclad:byte-array-to-hex-string 
-	     (ironclad:digest-file
-	      (read-from-string (iup:attribute (iup:handle "list") :valuestring))
-	      filename))))
+    (let* ((digest
+            (intern (iup:attribute (iup:handle "list") :valuestring) "IRONCLAD"))
+          (digest-hex 
+            (ironclad:byte-array-to-hex-string 
+             (ironclad:digest-file digest
+              filename))))
       (setf (iup:attribute (iup:handle "results") :append)
-	    (format nil "~A	~A" filename digest-hex)))
+            (format nil "~A	~A" filename digest-hex)))
     (iup:flush)
     iup:+default+)
 #+end_src

--- a/examples/callback.lisp
+++ b/examples/callback.lisp
@@ -8,23 +8,52 @@
 (in-package #:iup-examples.callback)
 
 (defun callback ()
-    (iup:with-iup ()
-      (let* ((button
-               (iup:button :title "&OK"
-                           :expand "YES"
-                           :tip "Exit button"
-                           :action (lambda (handle)
-                                     (iup:message "Message"
-                                                  (lisp-implementation-version))
-                                     iup:+close+)))
-             (label (iup:label :title (lisp-implementation-type)))
-             (vbox (iup:vbox (list label button)
-                             :gap "10"
-                             :margin "10x10"
-                             :alignment :acenter))
-             (dialog (iup:dialog vbox :title "Hello, World!")))
-        (iup:show dialog)
-        (iup:main-loop))))
+  (iup:with-iup ()
+    (let* ((button1
+             (iup:button :title "Test &1"
+                         :expand :yes
+                         :tip "Callback inline at control creation"
+                         :action (lambda (handle)
+                                   (message "button1's action callback")
+                                   iup:+default+)))
+           (button2
+             (iup:button :title "Test &2"
+                         :expand :yes
+                         :tip "Callback set later using (SETF (IUP:CALLBACK ..) ..)"))
+           (button3
+             (iup:button :title "Test &3"
+                         :expand :yes
+                         :tip "Callback example using symbol-referenced function at control creation"
+                         :action 'test3-callback))
+           (button4
+             (iup:button :title "Test &4"
+                         :expand :yes
+                         :tip "Callback example using symbol-referenced function later using (SETF (IUP:CALLBACK ..) ..)"))
+           (vbox
+             (iup:vbox (list button1 button2 button3 button4)
+                       :gap "10"
+                       :margin "10x10"
+                       :alignment :acenter))
+           (dialog
+             (iup:dialog vbox :title "Callback Example")))
+      (setf (iup:callback button2 :action)
+            (lambda (handle)
+              (message "button2's action callback")
+              iup:+default+))
+      (setf (iup:callback button4 :action) 'test4-callback)
+      (iup:show dialog)
+      (iup:main-loop))))
+
+(defun test3-callback (handle)
+  (message "button3's action callback")
+  iup:+default+)
+
+(defun test4-callback (handle)
+  (message "button4's action callback")
+  iup:+default+)
+
+(defun message (message)
+  (iup:message "Callback Example" message))
 
 #-sbcl (callback)
 

--- a/examples/drophash.lisp
+++ b/examples/drophash.lisp
@@ -10,31 +10,31 @@
 (defun drophash ()
   (iup:with-iup ()
     (let* ((list (iup:list :dropdown :yes
-			   :expand :horizontal
-			   :handlename "list"))
-	   (label (iup:flat-label :title "Drop files for hash"
-				  :alignment "ACENTER:ACENTER"
-				  :font "Helvetica, 24"
-				  :dropfilestarget :yes
-				  :dropfiles_cb 'drop-files-callback
-				  :expand :yes))
-	   (frame (iup:frame label))
-	   (results (iup:multi-line :expand :yes
-				    :readonly :yes
-				    :visiblelines 7
-				    :handlename "results"))
-	   (vbox (iup:vbox (list list
-				 frame
-				 (iup:sbox results :direction :north))
-			   :margin "10x10"
-			   :cgap 5))
-	   (dialog (iup:dialog vbox
-			       :title "Drop Hash"
-			       :size "HALFxHALF")))
+                           :expand :horizontal
+                           :handlename "list"))
+           (label (iup:flat-label :title "Drop files for hash"
+                                  :alignment "ACENTER:ACENTER"
+                                  :font "Helvetica, 24"
+                                  :dropfilestarget :yes
+                                  :dropfiles_cb 'drop-files-callback
+                                  :expand :yes))
+           (frame (iup:frame label))
+           (results (iup:multi-line :expand :yes
+                                    :readonly :yes
+                                    :visiblelines 7
+                                    :handlename "results"))
+           (vbox (iup:vbox (list list
+                                 frame
+                                 (iup:sbox results :direction :north))
+                           :margin "10x10"
+                           :cgap 5))
+           (dialog (iup:dialog vbox
+                               :title "Drop Hash"
+                               :size "HALFxHALF")))
       (loop for digest in (ironclad:list-all-digests)
-	    for i from 1
-	    do (setf (iup:attribute list i) digest)
-	    finally (setf (iup:attribute list :valuestring) 'ironclad:sha256))
+            for i from 1
+            do (setf (iup:attribute list i) digest)
+            finally (setf (iup:attribute list :valuestring) 'ironclad:sha256))
       (iup:show dialog)
       (iup:main-loop))))
 
@@ -42,11 +42,11 @@
   (let* ((digest
           (intern (iup:attribute (iup:handle "list") :valuestring) "IRONCLAD"))
         (digest-hex 
-	  (ironclad:byte-array-to-hex-string 
-	   (ironclad:digest-file digest
-	    filename))))
+          (ironclad:byte-array-to-hex-string 
+           (ironclad:digest-file digest
+            filename))))
     (setf (iup:attribute (iup:handle "results") :append)
-	  (format nil "~A	~A" filename digest-hex)))
+          (format nil "~A	~A" filename digest-hex)))
   (iup:flush)
   iup:+default+)
 

--- a/iup/callback.lisp
+++ b/iup/callback.lisp
@@ -31,3 +31,6 @@
 (defun find-callback (name handle)
   (check-type handle tecgraf-base:ihandle)
   (genhash:hashref (make-callback :name name :handle handle) *registered-callbacks*))
+
+(defun unregister-all-callbacks ()
+  (genhash:hashclr *registered-callbacks*))

--- a/iup/classes.lisp
+++ b/iup/classes.lisp
@@ -13,7 +13,8 @@
     (#\n . tecgraf-base:ihandle)))
 
 (defun class-callback-name (classname callback-name package)
-  (intern (format nil "~:@(~A-~A~)" classname callback-name) package))
+  (declare (ignore package))
+  (make-keyword (format nil "~:@(~A-~A~)" classname callback-name)))
 
 (defun check-callback-args (action args-list)
   (declare (ignore action args-list))

--- a/iup/iup.lisp
+++ b/iup/iup.lisp
@@ -15,6 +15,7 @@
   (unwind-protect
        (progn
 	 (funcall func))
+    (iup::unregister-all-callbacks)
     (iup:close)))
 
 (defmacro with-iup (() &body body)


### PR DESCRIPTION
Add better callback example. Fixes #34 